### PR TITLE
Add HybridSearch support

### DIFF
--- a/search.go
+++ b/search.go
@@ -190,14 +190,12 @@ func (c *Client) Search(searchReq *SearchRequest) (*SearchResponse, error) {
 		queryParams["searchMethod"] = *searchReq.SearchMethod
 	}
 	if searchReq.SearchMethod != nil && *searchReq.SearchMethod == "HYBRID" {
-		if searchReq.SearchMethod != nil && *searchReq.SearchMethod == "HYBRID" {
-			if searchReq.HybridParameters != nil {
-				if searchReq.HybridParameters.RankingMethod == "" {
-					searchReq.HybridParameters.RankingMethod = "rrf"
-				}
-				if searchReq.HybridParameters.RetrievalMethod == "" {
-					searchReq.HybridParameters.RetrievalMethod = "disjunction"
-				}
+		if searchReq.HybridParameters != nil {
+			if searchReq.HybridParameters.RankingMethod == "" {
+				searchReq.HybridParameters.RankingMethod = "rrf"
+			}
+			if searchReq.HybridParameters.RetrievalMethod == "" {
+				searchReq.HybridParameters.RetrievalMethod = "disjunction"
 			}
 		}
 


### PR DESCRIPTION
HybridSearch was released by Marqo a few months ago in v2.10

https://github.com/marqo-ai/marqo/blob/mainline/RELEASE.md#release-2100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new "HYBRID" search method, enhancing search options and flexibility.
	- Added a new `HybridParameters` struct to customize hybrid search configurations.

- **Improvements**
	- Updated search logic to manage hybrid searches, ensuring default values are provided when parameters are not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->