### PR TITLE
Add auth support for MarqoCloud

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,11 +22,19 @@ func WithLogger(logger *slog.Logger) func(*Client) {
 	}
 }
 
+// WithMarqoCloudAuth sets the API key for authentication if you are using MarqoCloud
+func WithMarqoCloudAuth(apiKey string) func(*Client) {
+	return func(c *Client) {
+		c.apiKey = apiKey
+	}
+}
+
 // Client is the client for the Marqo server
 type Client struct {
 	url       string
 	logger    *slog.Logger
 	reqClient *req.Client
+	apiKey    string // Field to hold the API key for use with MarqoCloud
 }
 
 // NewClient creates a new client for the Marqo server.
@@ -74,6 +82,11 @@ func NewClient(url string, opt ...Options) (*Client, error) {
 	if client.reqClient == nil {
 		client.reqClient = req.NewClient()
 		client.reqClient.BaseURL = url
+
+		// Add the API key header if provided
+		if client.apiKey != "" {
+			client.reqClient.SetCommonHeader("x-api-key", client.apiKey)
+		}
 	}
 
 	// set default logger


### PR DESCRIPTION
Allow user to provide an optional API key on client creation.
This key is passed as a header on every Marqo api call.
Docs (see MarqoCloud section):

https://docs.marqo.ai/latest/reference/api/search/search/#response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced authentication support for MarqoCloud service with the ability to set an API key.
	- Enhanced client functionality to include API key in request headers for secure communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->